### PR TITLE
Implement exclude button in the metadata column

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -24,8 +24,8 @@
                             <input type="text" name="include[]" placeholder="Include Text" required>
                         </div>
                     </div>
-                    <button type="button" onclick="addField('includeFields')">Add More</button>
-                    <button type="button" onclick="removeField('includeFields')">Remove</button>
+                    <button type="button" onclick="includeField('includeFields')">Add More</button>
+                    <button type="button" onclick="removeInput('includeFields')">Remove</button>
                 </div>
 
                 <!-- Exclude Section -->
@@ -36,8 +36,8 @@
                             <input type="text" name="exclude[]" placeholder="Exclude Text">
                         </div>
                     </div>
-                    <button type="button" onclick="addField('excludeFields')">Add More</button>
-                    <button type="button" onclick="removeField('excludeFields')">Remove</button>
+                    <button type="button" onclick="includeField('excludeFields')">Add More</button>
+                    <button type="button" onclick="removeInput('excludeFields')">Remove</button>
                 </div>
 
                 <!-- Budget Section -->
@@ -47,7 +47,7 @@
                 </div>
 
                 <br>
-                <input type="submit" value="Submit">
+                <input id="mainFormSubmit" type="submit" value="Submit">
             </form>
         </div>
         <div class="center-column">
@@ -60,8 +60,8 @@
             <h4 id="nodeId"></h4>
             <table id="metaDataTable"></table>
             <br>
-            <button id="metaDataInclude" type="button" onclick="addField('includeFields')" hidden>Include</button>
-            <button id="metaDataExclude" type="button" onclick="removeField('excludeFields')" hidden>Exclude</button>
+            <button id="metaDataInclude" type="button" onclick="includeField('includeFields')" hidden>Include</button>
+            <button id="metaDataExclude" type="button" onclick="removeField(this)" data-container-id="excludeFields" data-id="" hidden>Exclude</button>
           </form>
         </div>
     </div>
@@ -78,13 +78,48 @@
             }
 
             container.appendChild(field);
+            return field;
         }
 
-        function removeField(containerId) {
+        function includeField(containerId) {
+            var field = addField(containerId);
+            if (field == null){
+                console.log('Error creating field');
+            }
+        }
+
+        function removeInput(containerId) {
             const container = document.getElementById(containerId);
             const allFields = container.querySelectorAll('.dynamic-field');
             if (allFields.length > 1) {
                 allFields[allFields.length - 1].remove();
+            }
+        }
+
+        function removeField(element) {
+            debugger;
+            
+            const container = document.getElementById(element.dataset.containerId);
+            const allFields = container.querySelectorAll('.dynamic-field');
+            
+            if (allFields != null) {
+                var found = false;
+                for (var i = 0, n = allFields.length; i < n; i = i + 1) {
+                    found = allFields[i].children[0].value === element.dataset.id;
+
+                    if (found){
+                        return;
+                    }
+                }
+
+                var field = addField(element.dataset.containerId);
+                
+                if (field == null){
+                    console.log('Error creating field');
+                }
+
+                field.children[0].value = element.dataset.id;
+                document.getElementById('mainFormSubmit').click();
             }
         }
     </script>
@@ -124,6 +159,8 @@
                   document.getElementById("nodeId").textContent = this.data("id");
                   document.getElementById("metaDataInclude").removeAttribute('hidden');
                   document.getElementById("metaDataExclude").removeAttribute('hidden');
+                  document.getElementById("metaDataInclude").setAttribute('data-id', this.id());
+                  document.getElementById("metaDataExclude").setAttribute('data-id', this.id());
                   var table = document.getElementById("metaDataTable");
                   while (table.firstChild) {
                       table.removeChild(table.firstChild);


### PR DESCRIPTION
The functions of the exclude button in the metadata column were added. Now when the user clicks on a node in the graph and sees the metadata, the user has the option to exclude the node which will remove it from the graph visualization and add the node to the exclude list on the left column of the dashboard. 